### PR TITLE
Include rsyslog for container stdout logging capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,15 @@ RUN rpm -ivh http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm && \
                    patch \
                    python-ironicclient \
                    python2-openstackclient.noarch \
-                   tftp-server \
+                   rsyslog \
                    qemu-img \
                    syslinux \
+                   tftp-server \
                    wget &&\
     mv /etc/ironic/rootwrap.d /etc/rootwrap.d-ironic && \
     mkdir /tmp/patches
 COPY --from=ipxe-builder /tmp/ipxe/src/bin-x86_64-efi/ipxe.efi /usr/share/syslinux/custom-ipxe.efi
+COPY rsyslog.conf /etc/
 
 VOLUME /etc/ironic
 USER ironic:ironic

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,0 +1,4 @@
+$ModLoad imuxsock
+$ModLoad omstdout
+$OmitLocalLogging off
+*.* :omstdout:;RSYSLOG_TraditionalFileFormat


### PR DESCRIPTION
Allow ironic containers log to stdout via i.e.:
`CMD ["sh", "-c", "rsyslogd -n & /usr/bin/ironic-api --config-file /tmp/ironic.conf"]`