### PR TITLE
Enable legacy ipxe. Allow non-standard web port if default is taken.

### DIFF
--- a/ipxescript
+++ b/ipxescript
@@ -1,4 +1,5 @@
 #!ipxe
 
 dhcp
+isset http://${next-server}:6969/boot.ipxe && chain http://${next-server}:6969/boot.ipxe ||
 chain http://${next-server}/boot.ipxe


### PR DESCRIPTION
- Add legacy bios mode image
- Enable a non-standard web port (6969) to the ipxe bootchain - in case the default one is not available.